### PR TITLE
Fix of close button not working Issue #13

### DIFF
--- a/packages/ui/material/src/lib/modal.component.ts
+++ b/packages/ui/material/src/lib/modal.component.ts
@@ -139,7 +139,7 @@ export class HdWalletModalTriggerDirective extends ComponentStore<ViewModel> {
       <header>
         <button
           mat-icon-button
-          mat-dialog-close
+          (click)="onClose()"
           aria-label="Close wallet adapter selection"
         >
           <mat-icon>close</mat-icon>


### PR DESCRIPTION
"You'll need a wallet dialog" button doesn't close when you don't have any solana wallet installed.